### PR TITLE
Enumerate: getListEntry should return Maybe

### DIFF
--- a/examples/hidraw.hs
+++ b/examples/hidraw.hs
@@ -16,7 +16,7 @@ main = do
     e <- newEnumerate udev
     addMatchSubsystem e "hidraw"
     scanDevices e
-    ls <- getListEntry e
+    Just ls <- getListEntry e
     path  <- getName ls
     print path
     dev <- newFromSysPath udev path

--- a/src/System/UDev/Enumerate.hs
+++ b/src/System/UDev/Enumerate.hs
@@ -244,6 +244,8 @@ foreign import ccall unsafe "udev_enumerate_get_list_entry"
   c_getListEntry :: Enumerate -> IO List
 
 -- | Get the first entry of the sorted list of device paths.
-getListEntry :: Enumerate -> IO List
-getListEntry = c_getListEntry
+getListEntry :: Enumerate -> IO (Maybe List)
+getListEntry enumerate = do
+  xs <- c_getListEntry enumerate
+  return $ if xs == nil then Nothing else Just xs
 {-# INLINE getListEntry #-}


### PR DESCRIPTION
This fixes a dangerous inconsistency with List.getNext.
