### PR TITLE
Enable filterAddMatchSubsystemDevtype to work with devtype=NULL.

### DIFF
--- a/src/System/UDev/Device.hs
+++ b/src/System/UDev/Device.hs
@@ -15,6 +15,7 @@
 module System.UDev.Device
        ( Device
        , Devnum
+       , Action (..)
 
          -- * Create
        , newFromSysPath

--- a/src/System/UDev/Monitor.hs
+++ b/src/System/UDev/Monitor.hs
@@ -151,12 +151,16 @@ foreign import ccall unsafe "udev_monitor_filter_add_match_subsystem_devtype"
 -- The filter /must be/ installed before the monitor is switched to
 -- listening mode.
 --
-filterAddMatchSubsystemDevtype :: Monitor -> ByteString -> ByteString -> IO ()
-filterAddMatchSubsystemDevtype monitor subsystem devtype = do
+filterAddMatchSubsystemDevtype :: Monitor -> ByteString -> Maybe ByteString -> IO ()
+filterAddMatchSubsystemDevtype monitor subsystem mbDevtype = do
   throwErrnoIfMinus1_ "filterAddMatchSubsystemDevtype" $
     useAsCString subsystem $ \ c_subsystem ->
-      useAsCString devtype $ \ c_devtype   ->
-        c_filterAddMatchSubsystemDevtype monitor c_subsystem c_devtype
+      case mbDevtype of
+        Just devtype ->
+            useAsCString devtype $ \ c_devtype   ->
+              c_filterAddMatchSubsystemDevtype monitor c_subsystem c_devtype
+        Nothing ->
+              c_filterAddMatchSubsystemDevtype monitor c_subsystem nullPtr
 
 foreign import ccall unsafe "udev_monitor_filter_add_match_tag"
   c_filterAddMatchTag :: Monitor -> CString -> IO CInt


### PR DESCRIPTION
Initial implementation forces one to pass something as devtype. But according to udev_monitor_filter_add_match_subsystem_devtype documentation, one may pass devtype == NULL to do not filter by devtype. It is not possible to create instance of ByteString which would be converted to NULL, so I propose to use Maybe ByteString here.
